### PR TITLE
Remove unused require 'rake', which can cause gem to fail to install …

### DIFF
--- a/mailosaur.gemspec
+++ b/mailosaur.gemspec
@@ -1,4 +1,3 @@
-require 'rake'
 Gem::Specification.new do |s|
   s.name        = 'mailosaur'
   s.version     = '3.0.0'


### PR DESCRIPTION
…in Rubies that don't yet have rake installed

- [ ] @izagor 